### PR TITLE
Release/v0.8.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,43 @@
+# Changelog
+
+## 0.8.0
+
+### Added
+
+- Added new "Enforcement" section to settings. The primary purpose of this is to help filter against messages where the LLM returns a response indicating it is a language model. After doing this, it often fails to remember its personality. It can also be used to filter unwanted content from message responses in general, by prompting a request for a new response.
+
+### Changed
+
+- Moved position of button bar and status text to give more room for both.
+
+### Fixed
+
+- No longer show "X more text before speaking" in status if voice transcription isn't active.
+- Toggling off Speech Synthesis button now prevents Sock from talking out loud when responding.
+- "Thinking" visual will continue while speech synthesis is running and end before playback, so
+  so the entire "process user text -> go to LLM for response -> convert response to speech" process
+  smoothly has one whole thinking phase instead of a visual gap between LLM response and talking.
+
+## [Example]
+
+### Added
+
+- This section is for listing new features.
+
+### Changed
+
+- This section is for listing changes to existing functionality.
+
+### Deprecated
+
+- This section is for listing features that will soon be removed in future versions.
+- It's quite possible this will not be used in the context of a text.
+
+### Removed
+
+- This section is for listing features that have been removed.
+
+### Fixed
+
+- This section is for listing fixes to errors, bugs in features etc.
+- Changed is for non-fix changes, Fixed is for correcting bugs/issues.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Sock is an AI-controlled puppet that you can create your own custom avatar for a
 
 Sock operates through a [Next.js](https://nextjs.org/) application running in your web browser, which communicates with a [Python](https://www.python.org/downloads/) backend. This backend is responsible for managing the API calls to OpenAI, as well as running the Whisper transcription and Coqui-AI text-to-speech models.
 
-![Version](https://img.shields.io/badge/version-v0.6.1-blue)
+![Version](https://img.shields.io/badge/version-v0.8.0-blue)
 ![MIT License](https://img.shields.io/badge/license-MIT-green)
 ![ChatGPT](https://img.shields.io/badge/chatGPT-74aa9c?style=flat&logo=openai&logoColor=white)
 ![Next JS](https://img.shields.io/badge/Next-black?style=flat&logo=next.js&logoColor=white)

--- a/backend/config/config.json
+++ b/backend/config/config.json
@@ -5,21 +5,28 @@
                 "bgColor": "00FF00",
                 "layers": [
                     {
-                        "altPose1": "",
-                        "altPose2": "",
+                        "altPose1": "lookleft.png",
+                        "altPose2": "lookright.png",
                         "blinking": "blink.png",
                         "default": "default.png",
                         "id": 0,
                         "name": "Data Avatar",
-                        "path": "avatars/riot/",
+                        "path": "avatars/chuck/",
                         "talking": "talk.png",
-                        "talkingBlink": "talk_blink_open.png",
-                        "talkingBlinkClosed": "talk_blink_closed.png",
-                        "talkingClosedAlt": "talk_closed.png",
-                        "thinking": "think.png",
-                        "ttsBlinking": "tts_blink.png",
-                        "ttsDefault": "tts_default.png"
+                        "talkingClosedAlt": "default.png",
+                        "thinking": "think.png"
                     }
+                ]
+            },
+            "enforcement": {
+                "correctiveMessage": "Please remember you are not to behave like an AI model or LLM, and instead look at your system message that identifies you and behave from that.",
+                "giveupDefaultResponse": "Sorry, I got distracted and forgot what we were talking about. Could you rephrase that?",
+                "reattempts": 0,
+                "responseFilterList": [
+                    "openai",
+                    " gpt-3",
+                    " language model",
+                    " ai model"
                 ]
             },
             "identity": {
@@ -34,7 +41,7 @@
                 "nameHomonyms": [
                     "chuck",
                     " ciao",
-                    " chock"
+                    " chock "
                 ],
                 "personality": "You are Chuck, a quirky man who lives in western Washington in the Pacific Northwest, and are a co-host on a podcast. You have a good sense of humor and like to be zany and funny all the time. You like video games, especially the Legend of Zelda, love living in the Pacific Northwest, have too many baseball caps, and enjoy board games and doing yard work. You only ever speak in two sentences or less. You need to pay attention to what others are saying to you, however, and respond to what they're talking about. Be humorous and relaxed at all times. You never ask for more context or clarification, and you never say you don't understand. If you don't understand, instead say something silly and inane without apologizing. You never say you're sorry."
             },
@@ -60,51 +67,8 @@
                 }
             },
             "twitch": {
-                "channel": "wyspering",
-                "triggers": [
-                    {
-                        "action": "response",
-                        "command": "d7e16f76-14f9-4d18-82be-a67d10d3aa8c",
-                        "cooldown": 0,
-                        "description": "Talk to Riot",
-                        "id": 1691192084559,
-                        "isActive": true,
-                        "isBoundToRole": true,
-                        "rewardId": "",
-                        "role": "everyone",
-                        "text": "",
-                        "type": "reward",
-                        "user": "timor_jack"
-                    },
-                    {
-                        "action": "tts",
-                        "command": "a069f606-85a8-4589-b4e5-a0c6c775d649",
-                        "cooldown": 0,
-                        "description": "Conversation Reward",
-                        "id": 1691465769212,
-                        "isActive": true,
-                        "isBoundToRole": true,
-                        "rewardId": "",
-                        "role": "everyone",
-                        "text": "",
-                        "type": "reward",
-                        "user": ""
-                    },
-                    {
-                        "action": "say",
-                        "command": "!aboutriot",
-                        "cooldown": 0,
-                        "description": "About Riot",
-                        "id": 1691534775689,
-                        "isActive": true,
-                        "isBoundToRole": true,
-                        "rewardId": "",
-                        "role": "everyone",
-                        "text": "Hello, I'm Riot! I was made by Whysper with art by Adara, and code by Kyle, and I run on OpenAI's ChatGPT.",
-                        "type": "command",
-                        "user": ""
-                    }
-                ]
+                "channel": "",
+                "triggers": []
             }
         }
     ]

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -19,6 +19,8 @@ export const chat = async (
     max_tokens: maxTokens,
   };
 
+  console.log("request", request);
+
   const response = await fetch("http://127.0.0.1:8000/chat", {
     method: "POST",
     headers: {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,16 +1,16 @@
-@import url('../styles/avatar.css');
-@import url('../styles/colors.css');
-@import url('../styles/header.css');
-@import url('../styles/log.css');
-@import url('../styles/settings.css');
-@import url('../styles/transcription.css');
+@import url("../styles/avatar.css");
+@import url("../styles/colors.css");
+@import url("../styles/header.css");
+@import url("../styles/log.css");
+@import url("../styles/settings.css");
+@import url("../styles/transcription.css");
 
 .custom-shadow-sm {
-  box-shadow: 0 .125rem .25rem rgba(0,0,0,.5)!important;
+  box-shadow: 0 0.125rem 0.25rem rgba(0, 0, 0, 0.5) !important;
 }
 
 .custom-shadow-inset-sm {
-  box-shadow: inset 0 .125rem .25rem rgba(0,0,0,.5)!important;
+  box-shadow: inset 0 0.125rem 0.25rem rgba(0, 0, 0, 0.5) !important;
 }
 
 .fs-7 {
@@ -39,7 +39,7 @@
 
 .controls-wrapper {
   width: calc(100% - 650px);
-  min-width: 500px; 
+  min-width: 500px;
 }
 
 .activate-button {
@@ -47,5 +47,5 @@
 }
 
 .stat-holder {
-  width: calc(100% - 210px);
+  line-height: 30px !important;
 }

--- a/src/components/settings/children/enforcementSection/enforcementSection.tsx
+++ b/src/components/settings/children/enforcementSection/enforcementSection.tsx
@@ -1,0 +1,99 @@
+import { ChangeEvent, useContext } from "react";
+
+import { blankProfile, SettingsContext } from "@/state";
+
+export const EnforcementSection = () => {
+  const context = useContext(SettingsContext)!;
+  const { index, settings, setField } = context;
+  const { profiles } = settings;
+  const enforcement =
+    profiles[index].enforcement ??
+    JSON.parse(JSON.stringify(blankProfile.enforcement));
+
+  const getArrayField = (fieldName: string) => {
+    const field = (enforcement as any)[fieldName];
+    return field ? field.join(",") : "";
+  };
+
+  const handleChangeField = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>
+  ) => {
+    setField("enforcement", e.target.name, e.target.value);
+  };
+
+  const handleChangeFieldAsNumber = (e: ChangeEvent<HTMLInputElement>) => {
+    setField("enforcement", e.target.name, Number(e.target.value));
+  };
+
+  const handleChangeArrayField = (e: ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.split(",");
+    setField("enforcement", e.target.name, value);
+  };
+
+  return (
+    <fieldset>
+      <legend>Enforcement</legend>
+      <div className="row">
+        <div className="col-8 mb-3">
+          <label className="form-label">Response Filter List</label>
+          <p className="tip">
+            Comma separated list of words or phrases that, if returned from the
+            LLM, will trigger an attempt to re-prompt the LLM for a different
+            response.
+          </p>
+          <input
+            name="responseFilterList"
+            type="text"
+            className="form-control"
+            placeholder="e.g. OpenAI, LLM, language model"
+            value={getArrayField("responseFilterList")}
+            onChange={handleChangeArrayField}
+          />
+        </div>
+        <div className="col-4 mb-3">
+          <label className="form-label">Reattempts</label>
+          <p className="tip">
+            Number of reattempts to get unfiltered response before giving up.
+          </p>
+          <input
+            name="reattempts"
+            type="number"
+            className="form-control"
+            placeholder="e.g. 1"
+            value={enforcement.reattempts}
+            onChange={handleChangeFieldAsNumber}
+          />
+        </div>
+        <div className="col-12 mb-3">
+          <label className="form-label">Corrective Message for LLM</label>
+          <p className="tip">
+            An optional corrective statement to give the LLM to get it to think
+            clearly before a reattempt
+          </p>
+          <input
+            name="correctiveMessage"
+            type="text"
+            className="form-control"
+            placeholder="e.g. You are not to behave like an AI model or LLM, and instead look at your system message that identifies you and behave from that."
+            value={enforcement.correctiveMessage}
+            onChange={handleChangeField}
+          />
+        </div>
+        <div className="col-12 mb-3">
+          <label className="form-label">Give-Up Default Response</label>
+          <p className="tip">
+            A response to come from the puppet if the reattempts are exhausted.
+          </p>
+          <input
+            name="giveupDefaultResponse"
+            type="text"
+            className="form-control"
+            placeholder="e.g. Sorry, I got distracted and forgot what we were talking about. Could you rephrase that?"
+            value={enforcement.giveupDefaultResponse}
+            onChange={handleChangeField}
+          />
+        </div>
+      </div>
+    </fieldset>
+  );
+};

--- a/src/components/settings/children/enforcementSection/index.ts
+++ b/src/components/settings/children/enforcementSection/index.ts
@@ -1,0 +1,1 @@
+export * from "./enforcementSection";

--- a/src/components/settings/children/index.ts
+++ b/src/components/settings/children/index.ts
@@ -1,4 +1,5 @@
 export * from "./avatarSection";
+export * from "./enforcementSection";
 export * from "./identitySection";
 export * from "./openAiSection";
 export * from "./settingsNav";

--- a/src/components/settings/children/settingsNav/settingsNav.tsx
+++ b/src/components/settings/children/settingsNav/settingsNav.tsx
@@ -18,6 +18,8 @@ export const SettingsNav = () => {
   const { profiles } = settings;
   const [buttonText, setButtonText] = useState("Save");
 
+  console.log("settings", settings);
+
   const handleTabClick = (e: any) => {
     e.preventDefault();
     const tab = e.target.getAttribute("href")?.replace("#", "");
@@ -49,7 +51,7 @@ export const SettingsNav = () => {
 
   return (
     <div className="row">
-      <div className="col-4">
+      <div className="col-6">
         <ul className="nav settings-nav">
           <li className="nav-item">
             <a
@@ -58,6 +60,17 @@ export const SettingsNav = () => {
               onClick={handleTabClick}
             >
               Identity
+            </a>
+          </li>
+          <li className="nav-item">
+            <a
+              className={`nav-link ${
+                activeTab === "enforcement" ? "active" : ""
+              }`}
+              href="#enforcement"
+              onClick={handleTabClick}
+            >
+              Enforcement
             </a>
           </li>
           <li className="nav-item">
@@ -98,7 +111,7 @@ export const SettingsNav = () => {
           </li>
         </ul>
       </div>
-      <div className="col-8 text-end">
+      <div className="col-6 text-end">
         <span className="me-3 d-inline-block align-middle">Profile:</span>
         <select
           className="form-select profile-select d-inline-block w-auto align-top me-2"

--- a/src/components/settings/settings.tsx
+++ b/src/components/settings/settings.tsx
@@ -1,10 +1,10 @@
-import { ChangeEvent, FormEvent, useContext, useEffect, useState } from "react";
+import { FormEvent, useContext, useEffect, useState } from "react";
 
-import { Icons } from "@/components";
 import { SettingsContext } from "@/state";
 
 import {
   AvatarSection,
+  EnforcementSection,
   IdentitySection,
   OpenAiSection,
   SettingsNav,
@@ -19,18 +19,7 @@ type SettingsProps = {
 export const Settings = (props: SettingsProps) => {
   const { onChangeTab } = props;
   const context = useContext(SettingsContext)!;
-  const {
-    activeTab,
-    addProfile,
-    changeIndex,
-    deleteCurrentProfile,
-    index,
-    isDirty,
-    loadSettings,
-    settings,
-    saveSettings,
-  } = context;
-  const { profiles } = settings;
+  const { activeTab, isDirty, loadSettings, saveSettings } = context;
   const [buttonText, setButtonText] = useState("Save");
 
   useEffect(() => {
@@ -44,6 +33,7 @@ export const Settings = (props: SettingsProps) => {
 
   useEffect(() => {
     onChangeTab(activeTab);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab]);
 
   useEffect(() => {
@@ -56,17 +46,6 @@ export const Settings = (props: SettingsProps) => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isDirty]);
-
-  const handleDeleteProfile = () => {
-    if (window.confirm("Are you sure you want to delete this profile?")) {
-      deleteCurrentProfile();
-    }
-  };
-
-  const handleIndexChange = (e: ChangeEvent<HTMLSelectElement>) => {
-    const value = parseInt(e.target.value);
-    changeIndex(value);
-  };
 
   const onFormSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -87,6 +66,7 @@ export const Settings = (props: SettingsProps) => {
         <SettingsNav />
         <hr />
         {activeTab === "identity" && <IdentitySection />}
+        {activeTab === "enforcement" && <EnforcementSection />}
         {activeTab === "gpt" && <OpenAiSection />}
         {activeTab === "voice" && <TtsSection />}
         {activeTab === "twitch" && <TwitchSection />}

--- a/src/components/stage/children/buttonBar.tsx
+++ b/src/components/stage/children/buttonBar.tsx
@@ -34,8 +34,8 @@ export const ButtonBar = (props: ButtonBarProps) => {
   };
 
   return (
-    <div className="d-inline-block me-2">
-      <div className="mb-2">
+    <div className="">
+      <div id="power-button" className="mb-2 d-inline-block me-2">
         <button
           className={`activate-button btn ${
             isActive ? "btn-secondary" : "btn-primary"
@@ -47,9 +47,9 @@ export const ButtonBar = (props: ButtonBarProps) => {
           {isActive ? "Deactivate" : "Activate"}
         </button>
       </div>
-      <div>
+      <div className="d-inline-block">
         <button
-          className={`btn btn-primary d-inline-block bg-gradient custom-shadow-sm me-2 px-2 ${
+          className={`btn btn-primary btn-lg d-inline-block bg-gradient custom-shadow-sm me-2 px-2 ${
             isTranscriptionActive ? "" : "text-dark"
           }`}
           title={
@@ -63,7 +63,7 @@ export const ButtonBar = (props: ButtonBarProps) => {
           <Icons.Ear isActive={isTranscriptionActive} />
         </button>
         <button
-          className={`btn btn-primary d-inline-block bg-gradient custom-shadow-sm me-2 px-2 ${
+          className={`btn btn-primary btn-lg d-inline-block bg-gradient custom-shadow-sm me-2 px-2 ${
             isSpeechSynthesisActive ? "" : "text-dark"
           }`}
           onClick={onToggleSpeechSynthesisClick}
@@ -77,7 +77,7 @@ export const ButtonBar = (props: ButtonBarProps) => {
           <Icons.Speaker isActive={isSpeechSynthesisActive} />
         </button>
         <button
-          className={`btn btn-primary d-inline-block bg-gradient custom-shadow-sm me-2 px-2 ${
+          className={`btn btn-primary btn-lg d-inline-block bg-gradient custom-shadow-sm me-2 px-2 ${
             isChatReadOutloud ? "" : "text-dark"
           }`}
           title={isChatReadOutloud ? "Don't read outloud" : "Read chat outloud"}
@@ -94,7 +94,7 @@ export const ButtonBar = (props: ButtonBarProps) => {
           <Icons.ChatLeftQuote />
         </button>*/}
         <button
-          className={`btn btn-primary d-inline-block bg-gradient custom-shadow-sm me-2 px-2 ${
+          className={`btn btn-primary btn-lg d-inline-block bg-gradient custom-shadow-sm me-2 px-2 ${
             isTwitchActive ? "" : "text-dark"
           }`}
           title={
@@ -106,7 +106,7 @@ export const ButtonBar = (props: ButtonBarProps) => {
           <Icons.Twitch />
         </button>
         <button
-          className={`btn btn-primary d-inline-block bg-gradient custom-shadow-sm px-2 ${
+          className={`btn btn-primary btn-lg d-inline-block bg-gradient custom-shadow-sm px-2 ${
             onlyRespondWhenSpokenTo ? "" : "text-dark"
           }`}
           title={

--- a/src/components/stage/children/status.tsx
+++ b/src/components/stage/children/status.tsx
@@ -29,57 +29,61 @@ export const Status = () => {
   }
 
   return (
-    <div className="stat-holder d-inline-block align-top text-end fs-7">
-      <div className="session-usage">
+    <div className="stat-holder text-end fs-7 mb-1">
+      <span className="session-usage">
         <span>Tokens: {formatNumber(tokensUsed, 5)}</span>
         <span> • </span>
         <span>Session Cost ${calculateSessionCost()}</span>
-      </div>
-      <div className="performance">
+        <span> • </span>
+      </span>
+      <span className="performance">
         <span>Transcribe: {transcriptionTime}s</span>
         <span> • </span>
         <span>LLM: {aiTime}s</span>
         <span> • </span>
         <span>TTS: {ttsTime}s</span>
-      </div>
-      <div className="words-left">
-        {onlyRespondWhenSpokenTo ? (
-          <div>Only responds after name is spoken</div>
-        ) : (
-          <div>
-            Talks after {wordCountBeforeResponse - wordCount} more words
-          </div>
-        )}
-      </div>
-      <div className="API Statuses">
+      </span>
+      {isTranscribing && (
+        <span className="words-left">
+          <span> • </span>
+          {onlyRespondWhenSpokenTo ? (
+            <span>Only responds after name is spoken</span>
+          ) : (
+            <span>
+              Talks after {wordCountBeforeResponse - wordCount} more words
+            </span>
+          )}
+        </span>
+      )}
+      <span className="API Statuses d-inline-block align-middle ms-4">
         <small
-          className={`d-inline-flex mt-1 px-1 py-1 mb-0 fw-semibold bg-gray-800 border ${
+          className={`d-inline-flex px-1 py-1 mb-0 fw-semibold bg-gray-800 border ${
             isTranscribing
               ? "text-white border-white"
-              : "text-primary-emphasis border-primary-subtle"
+              : "text-primary-emphasis border-primary"
           } rounded-2 me-2`}
         >
           <Icons.Ear />
         </small>
         <small
-          className={`d-inline-flex mt-1 px-1 py-1 mb-0 fw-semibold bg-gray-800 border ${
+          className={`d-inline-flex px-1 py-1 mb-0 fw-semibold bg-gray-800 border ${
             isThinking
               ? "text-white border-white"
-              : "text-primary-emphasis border-primary-subtle"
+              : "text-primary-emphasis border-primary"
           } rounded-2 me-2`}
         >
           <Icons.CPU />
         </small>
         <small
-          className={`d-inline-flex mt-1 px-1 py-1 mb-0 fw-semibold bg-gray-800 border ${
+          className={`d-inline-flex px-1 py-1 mb-0 fw-semibold bg-gray-800 border ${
             isSpeaking
               ? "text-white border-white"
-              : "text-primary-emphasis border-primary-subtle"
+              : "text-primary-emphasis border-primary"
           } rounded-2`}
         >
           <Icons.ChatLeftQuote />
         </small>
-      </div>
+      </span>
     </div>
   );
 };

--- a/src/state/settingsContext.tsx
+++ b/src/state/settingsContext.tsx
@@ -1,12 +1,12 @@
 import React, { createContext, useMemo, useState } from "react";
-import { SettingsContextType, Settings } from "@/types";
+import { SettingsContextType, SettingsProfile, Settings } from "@/types";
 import { api } from "@/api";
 
 type SettingsProviderProps = {
   children: React.ReactNode;
 };
 
-const blankProfile = {
+export const blankProfile: SettingsProfile = {
   saveFileVersion: "1.0.0",
   identity: {
     name: "",
@@ -15,6 +15,20 @@ const blankProfile = {
     attentionWords: [],
     chattiness: 7.6,
     memory: 750,
+  },
+  enforcement: {
+    responseFilterList: [
+      "openai",
+      "gpt-3",
+      "language model",
+      "llm",
+      "chat gpt",
+    ],
+    reattempts: 3,
+    correctiveMessage:
+      "Please remember you are not to behave like an AI model or LLM, and instead look at your system message that identifies you and behave from that.",
+    giveupDefaultResponse:
+      "Sorry, I got distracted and forgot what we were talking about. Could you rephrase that?",
   },
   openAiApi: {
     temperature: 1,
@@ -53,6 +67,15 @@ const blankProfile = {
         altPose1: "",
         altPose2: "",
         default: "",
+        angryDefault: "",
+        angryBlinking: "",
+        angryTalking: "",
+        talkingClosedAlt: "",
+        talkingBlink: "",
+        talkingBlinkClosed: "",
+        ttsDefault: "",
+        ttsBlinking: "",
+        ttsTalking: "",
       },
     ],
   },
@@ -108,8 +131,15 @@ export const SettingsProvider = (props: SettingsProviderProps) => {
     setIsDirty(false);
   };
 
-  const setField = (section: string, field: string, value: any) => {
+  const setField = (
+    section: keyof SettingsProfile,
+    field: string,
+    value: any
+  ) => {
     let profile: any = getCurrentProfile();
+    if (!profile[section]) {
+      profile[section] = JSON.parse(JSON.stringify(blankProfile[section]));
+    }
     profile[section][field] = value;
     updateCurrentProfile(profile);
   };

--- a/src/styles/log.css
+++ b/src/styles/log.css
@@ -1,8 +1,8 @@
 .log {
-  height: 524px;
+  height: 560px;
 }
 
-.log-content { 
+.log-content {
   color: var(--lcars-red);
   height: 450px;
   overflow-y: scroll;
@@ -35,4 +35,3 @@
   display: block;
   height: 1px;
 }
-

--- a/src/types/contextTypes.ts
+++ b/src/types/contextTypes.ts
@@ -11,7 +11,7 @@ export type SettingsContextType = {
   saveSettings: () => Promise<void>;
   settings: Settings;
   setActiveTab: (tab: string) => void;
-  setField: (section: string, field: string, value: any) => void;
+  setField: (section: keyof SettingsProfile, field: string, value: any) => void;
   setIsDirty: React.Dispatch<React.SetStateAction<boolean>>;
   setLayerField: (layer: number, field: string, value: any) => void;
   setTriggerField: (index: number, field: string, value: any) => void;
@@ -83,6 +83,7 @@ export type Settings = {
 export type SettingsProfile = {
   saveFileVersion: string;
   identity: IdentitySettings;
+  enforcement: EnforcementSettings;
   openAiApi: OpenAiApiSettings;
   tts: TtsSettings;
   twitch: TwitchSettings;
@@ -96,6 +97,13 @@ export type IdentitySettings = {
   attentionWords: string[];
   chattiness: number;
   memory: number;
+};
+
+export type EnforcementSettings = {
+  responseFilterList: string[];
+  reattempts: number;
+  correctiveMessage: string;
+  giveupDefaultResponse: string;
 };
 
 export type OpenAiApiSettings = {


### PR DESCRIPTION
### Added

- Added new "Enforcement" section to settings. The primary purpose of this is to help filter against messages where the LLM returns a response indicating it is a language model. After doing this, it often fails to remember its personality. It can also be used to filter unwanted content from message responses in general, by prompting a request for a new response.

### Changed

- Moved position of button bar and status text to give more room for both.

### Fixed

- No longer show "X more text before speaking" in status if voice transcription isn't active.
- Toggling off Speech Synthesis button now prevents Sock from talking out loud when responding.
- "Thinking" visual will continue while speech synthesis is running and end before playback, so
  so the entire "process user text -> go to LLM for response -> convert response to speech" process
  smoothly has one whole thinking phase instead of a visual gap between LLM response and talking.